### PR TITLE
일일 업무 CRUD 구현

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -17,6 +17,7 @@ env:
   DB_URL: jdbc:mysql://localhost:3306/amatda
   DB_USERNAME: root
   DB_PASSWORD: root
+  DDL_AUTO: create
   JWT_SECRET: ${{ secrets.JWT_SECRET }} 
 
 permissions:

--- a/src/main/java/com/antk7894/amatda/configuration/SecurityConfig.java
+++ b/src/main/java/com/antk7894/amatda/configuration/SecurityConfig.java
@@ -1,4 +1,4 @@
-package com.antk7894.amatda.configuration.security;
+package com.antk7894.amatda.configuration;
 
 import com.antk7894.amatda.filter.JwtAuthenticationFilter;
 import com.antk7894.amatda.jwt.JwtTokenProvider;

--- a/src/main/java/com/antk7894/amatda/controller/DailyController.java
+++ b/src/main/java/com/antk7894/amatda/controller/DailyController.java
@@ -1,0 +1,73 @@
+package com.antk7894.amatda.controller;
+
+import com.antk7894.amatda.dto.daily.DailyCreateRequestDto;
+import com.antk7894.amatda.dto.daily.DailyPatchRequestDto;
+import com.antk7894.amatda.dto.daily.DailyUpdateRequestDto;
+import com.antk7894.amatda.entity.Daily;
+import com.antk7894.amatda.entity.planner.Planner;
+import com.antk7894.amatda.service.DailyReadService;
+import com.antk7894.amatda.service.DailyService;
+import com.antk7894.amatda.service.PlannerReadService;
+import com.antk7894.amatda.util.CustomSecurityUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+import java.net.URI;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/daily")
+public class DailyController {
+
+    private final DailyService dailyService;
+    private final DailyReadService dailyReadService;
+    private final PlannerReadService plannerReadService;
+
+    @GetMapping
+    public ResponseEntity<Page<Daily>> all(Pageable pageable) {
+        Planner planner = plannerReadService.findOneByEmail(CustomSecurityUtil.getCurrentUserEmail());
+        return ResponseEntity.ok(dailyReadService.findAll(planner, pageable));
+    }
+
+    @GetMapping("/{dailyId}")
+    public ResponseEntity<Daily> one(@PathVariable Long dailyId) {
+        Planner planner = plannerReadService.findOneByEmail(CustomSecurityUtil.getCurrentUserEmail());
+        return ResponseEntity.ok(dailyReadService.findOneById(planner, dailyId));
+    }
+
+    @PostMapping
+    public ResponseEntity<Daily> newDaily(@RequestBody DailyCreateRequestDto dto) {
+        Planner planner = plannerReadService.findOneByEmail(CustomSecurityUtil.getCurrentUserEmail());
+        Daily daily = dailyService.saveOne(planner, dto);
+        String currentUri = ServletUriComponentsBuilder.fromCurrentRequestUri().toUriString();
+        return ResponseEntity.created(URI.create(currentUri + "/" + daily.getDailyId())).body(daily);
+    }
+
+    @PutMapping("/{dailyId}")
+    public ResponseEntity<Daily> updateDaily(@PathVariable Long dailyId, @RequestBody DailyUpdateRequestDto dto) {
+        Planner planner = plannerReadService.findOneByEmail(CustomSecurityUtil.getCurrentUserEmail());
+        return ResponseEntity.ok(dailyService.updateOne(planner, dailyId, dto));
+    }
+
+    @PatchMapping("/{dailyId}")
+    public ResponseEntity<Daily> manipulateDaily(@PathVariable Long dailyId, @RequestBody DailyPatchRequestDto dto) {
+        Planner planner = plannerReadService.findOneByEmail(CustomSecurityUtil.getCurrentUserEmail());
+        return switch (dto.action()) {
+            case FINISH -> ResponseEntity.ok(dailyService.finishOne(planner, dailyId));
+            case RESET -> ResponseEntity.ok(dailyService.resetOne(planner, dailyId));
+        };
+    }
+
+    @DeleteMapping("/{dailyId}")
+    public ResponseEntity<?> deleteDaily(@PathVariable Long dailyId) {
+        Planner planner = plannerReadService.findOneByEmail(CustomSecurityUtil.getCurrentUserEmail());
+        dailyService.removeOne(planner, dailyId);
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).body(null);
+    }
+
+}

--- a/src/main/java/com/antk7894/amatda/dto/daily/DailyAction.java
+++ b/src/main/java/com/antk7894/amatda/dto/daily/DailyAction.java
@@ -1,0 +1,6 @@
+package com.antk7894.amatda.dto.daily;
+
+public enum DailyAction {
+    FINISH,
+    RESET
+}

--- a/src/main/java/com/antk7894/amatda/dto/daily/DailyCreateRequestDto.java
+++ b/src/main/java/com/antk7894/amatda/dto/daily/DailyCreateRequestDto.java
@@ -1,0 +1,7 @@
+package com.antk7894.amatda.dto.daily;
+
+public record DailyCreateRequestDto(
+        String title,
+        String description
+) {
+}

--- a/src/main/java/com/antk7894/amatda/dto/daily/DailyPatchRequestDto.java
+++ b/src/main/java/com/antk7894/amatda/dto/daily/DailyPatchRequestDto.java
@@ -1,0 +1,6 @@
+package com.antk7894.amatda.dto.daily;
+
+public record DailyPatchRequestDto (
+        DailyAction action
+) {
+}

--- a/src/main/java/com/antk7894/amatda/dto/daily/DailyUpdateRequestDto.java
+++ b/src/main/java/com/antk7894/amatda/dto/daily/DailyUpdateRequestDto.java
@@ -1,0 +1,7 @@
+package com.antk7894.amatda.dto.daily;
+
+public record DailyUpdateRequestDto (
+        String title,
+        String description
+) {
+}

--- a/src/main/java/com/antk7894/amatda/entity/Daily.java
+++ b/src/main/java/com/antk7894/amatda/entity/Daily.java
@@ -2,13 +2,13 @@ package com.antk7894.amatda.entity;
 
 import com.antk7894.amatda.entity.auditing.TimeTrackedEntity;
 import com.antk7894.amatda.entity.planner.Planner;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Getter
 @Entity
+@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Daily extends TimeTrackedEntity {
 
@@ -16,14 +16,16 @@ public class Daily extends TimeTrackedEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long dailyId;
 
+    @JsonIgnore
     @JoinColumn(name = "planner_id")
-    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @ManyToOne(fetch = FetchType.LAZY)
     private Planner planner;
 
     private String title;
 
     private String description;
 
+    @Setter
     private boolean isFinished;
 
     public Daily(Planner planner, String title, String description, boolean isFinished) {
@@ -31,6 +33,11 @@ public class Daily extends TimeTrackedEntity {
         this.title = title;
         this.description = description;
         this.isFinished = isFinished;
+    }
+
+    public void updateTitleAndDescription(String title, String description) {
+        this.title = title;
+        this.description = description;
     }
 
 }

--- a/src/main/java/com/antk7894/amatda/entity/Schedule.java
+++ b/src/main/java/com/antk7894/amatda/entity/Schedule.java
@@ -19,7 +19,7 @@ public class Schedule extends TimeTrackedEntity {
     private Long scheduleId;
 
     @JoinColumn(name = "planner_id")
-    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @ManyToOne(fetch = FetchType.LAZY)
     private Planner planner;
 
     private String title;

--- a/src/main/java/com/antk7894/amatda/entity/Task.java
+++ b/src/main/java/com/antk7894/amatda/entity/Task.java
@@ -19,7 +19,7 @@ public class Task extends TimeTrackedEntity {
     private Long taskId;
 
     @JoinColumn(name = "planner_id")
-    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @ManyToOne(fetch = FetchType.LAZY)
     private Planner planner;
 
     private String title;

--- a/src/main/java/com/antk7894/amatda/entity/planner/Planner.java
+++ b/src/main/java/com/antk7894/amatda/entity/planner/Planner.java
@@ -29,4 +29,8 @@ public class Planner extends TimeTrackedEntity {
         this.role = role;
     }
 
+    public boolean hasSameId(Planner planner) {
+        return plannerId.longValue() == planner.getPlannerId().longValue();
+    }
+
 }

--- a/src/main/java/com/antk7894/amatda/repository/DailyRepository.java
+++ b/src/main/java/com/antk7894/amatda/repository/DailyRepository.java
@@ -1,0 +1,13 @@
+package com.antk7894.amatda.repository;
+
+import com.antk7894.amatda.entity.Daily;
+import com.antk7894.amatda.entity.planner.Planner;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DailyRepository extends JpaRepository<Daily, Long> {
+
+    Page<Daily> findByPlanner(Planner planner, Pageable pageable);
+
+}

--- a/src/main/java/com/antk7894/amatda/service/DailyReadService.java
+++ b/src/main/java/com/antk7894/amatda/service/DailyReadService.java
@@ -1,0 +1,40 @@
+package com.antk7894.amatda.service;
+
+import com.antk7894.amatda.entity.Daily;
+import com.antk7894.amatda.entity.planner.Planner;
+import com.antk7894.amatda.entity.planner.UserRole;
+import com.antk7894.amatda.repository.DailyRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class DailyReadService {
+
+    private final DailyRepository dailyRepository;
+
+    public Page<Daily> findAll(Planner planner, Pageable pageable) {
+        return switch (planner.getRole()) {
+            case ADMIN -> dailyRepository.findAll(pageable);
+            case USER -> dailyRepository.findByPlanner(planner, pageable);
+        };
+    }
+
+    public Daily findOneById(Planner planner, Long dailyId) {
+        Daily daily = dailyRepository.findById(dailyId).orElseThrow();
+        checkAuthForRead(planner, daily);
+        return dailyRepository.findById(dailyId).orElseThrow();
+    }
+
+    private void checkAuthForRead(Planner planner, Daily daily) {
+        if (!planner.getRole().equals(UserRole.ADMIN) && !planner.hasSameId(daily.getPlanner())) {
+            throw new RuntimeException("수정할 권한 없음");
+            // TODO 글로벌 예외 처리
+        }
+    }
+
+}

--- a/src/main/java/com/antk7894/amatda/service/DailyService.java
+++ b/src/main/java/com/antk7894/amatda/service/DailyService.java
@@ -1,0 +1,62 @@
+package com.antk7894.amatda.service;
+
+import com.antk7894.amatda.dto.daily.DailyCreateRequestDto;
+import com.antk7894.amatda.dto.daily.DailyUpdateRequestDto;
+import com.antk7894.amatda.entity.Daily;
+import com.antk7894.amatda.entity.planner.Planner;
+import com.antk7894.amatda.entity.planner.UserRole;
+import com.antk7894.amatda.repository.DailyRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class DailyService {
+
+    private final DailyRepository dailyRepository;
+
+    public Daily saveOne(Planner planner, DailyCreateRequestDto dto) {
+        Daily daily = new Daily(planner, dto.title(), dto.description(), false);
+        return dailyRepository.save(daily);
+    }
+
+    @Transactional
+    public Daily updateOne(Planner planner, Long dailyId, DailyUpdateRequestDto dto) {
+        Daily daily = dailyRepository.findById(dailyId).orElseThrow();
+        checkAuthForUpdate(planner, daily);
+        daily.updateTitleAndDescription(dto.title(), dto.description());
+        return daily;
+    }
+
+    @Transactional
+    public Daily finishOne(Planner planner, Long dailyId) {
+        Daily daily = dailyRepository.findById(dailyId).orElseThrow();
+        checkAuthForUpdate(planner, daily);
+        daily.setFinished(true);
+        return daily;
+    }
+
+    @Transactional
+    public Daily resetOne(Planner planner, Long dailyId) {
+        Daily daily = dailyRepository.findById(dailyId).orElseThrow();
+        checkAuthForUpdate(planner, daily);
+        daily.setFinished(false);
+        return daily;
+    }
+
+    @Transactional
+    public void removeOne(Planner planner, Long dailyId) {
+        Daily daily = dailyRepository.findById(dailyId).orElseThrow();
+        checkAuthForUpdate(planner, daily);
+        dailyRepository.delete(daily);
+    }
+
+    private void checkAuthForUpdate(Planner planner, Daily daily) {
+        if (!planner.getRole().equals(UserRole.ADMIN) && !planner.hasSameId(daily.getPlanner())) {
+            throw new RuntimeException("수정할 권한 없음");
+            // TODO 글로벌 예외 처리
+        }
+    }
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,7 +7,7 @@ spring:
   jpa:
     open-in-view: false
     hibernate:
-      ddl-auto: create
+      ddl-auto: ${DDL_AUTH}
     properties:
       hibernate:
         default_batch_fetch_size: 100


### PR DESCRIPTION
일일 업무`daily` 엔티티 관련 **CRUD 구현**하였음(**spring mvc 패턴** 활용)

- [x] `DailyController` 구현
- [x] `DailyService` 구현
- [x] `DailyRepository` 구현

관련 정책은 다음과 같다
- 사용자는 본인이 만든 일일 업무에 대해서 만 조회 및 수정(삭제)가 가능함
- 관리자는 모든 일일 업무에 대해 모든 작업 수행이 가능함
- 작업은 `FINISH`(수행 완료) 혹은 `RESET`(미 수행) 상태를 가짐

This Closes #5 