### PR TITLE
글로벌 예외 처리 핸들러 구현

### DIFF
--- a/src/main/java/com/antk7894/amatda/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/antk7894/amatda/exception/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.antk7894.amatda.exception;
 
+import com.antk7894.amatda.exception.custom.NoAuthenticationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -12,6 +13,12 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(NoSuchElementException.class)
     public ResponseEntity<?> notFoundHandle(NoSuchElementException exception) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(null);
+    }
+
+    @ExceptionHandler(NoAuthenticationException.class)
+    public ResponseEntity<?> noAuthenticationHandle(NoAuthenticationException exception) {
+        System.out.println(exception.getMessage());
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(null);
     }
 

--- a/src/main/java/com/antk7894/amatda/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/antk7894/amatda/exception/GlobalExceptionHandler.java
@@ -1,0 +1,18 @@
+package com.antk7894.amatda.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.NoSuchElementException;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(NoSuchElementException.class)
+    public ResponseEntity<?> notFoundHandle(NoSuchElementException exception) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(null);
+    }
+
+}

--- a/src/main/java/com/antk7894/amatda/exception/custom/NoAuthenticationException.java
+++ b/src/main/java/com/antk7894/amatda/exception/custom/NoAuthenticationException.java
@@ -1,0 +1,9 @@
+package com.antk7894.amatda.exception.custom;
+
+public class NoAuthenticationException extends RuntimeException {
+
+    public NoAuthenticationException(Long userId, String resourceName, Long resourceId) {
+        super(String.format("user id=%d has no authentication about this resource: %s id=%d", userId, resourceName, resourceId));
+    }
+
+}

--- a/src/main/java/com/antk7894/amatda/service/DailyService.java
+++ b/src/main/java/com/antk7894/amatda/service/DailyService.java
@@ -5,6 +5,7 @@ import com.antk7894.amatda.dto.daily.request.DailyUpdateDto;
 import com.antk7894.amatda.entity.Daily;
 import com.antk7894.amatda.entity.planner.Planner;
 import com.antk7894.amatda.entity.planner.UserRole;
+import com.antk7894.amatda.exception.custom.NoAuthenticationException;
 import com.antk7894.amatda.repository.DailyRepository;
 import com.antk7894.amatda.util.SecurityService;
 import lombok.RequiredArgsConstructor;
@@ -12,8 +13,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.NoSuchElementException;
 
 @Service
 @Transactional
@@ -75,7 +74,7 @@ public class DailyService {
     private void checkAuth(Daily daily) {
         Planner planner = securityService.getCurrentUser();
         if (!planner.getRole().equals(UserRole.ADMIN) && !planner.hasSameId(daily.getPlanner())) {
-            throw new NoSuchElementException();
+            throw new NoAuthenticationException(planner.getPlannerId(), daily.getClass().getSimpleName(), daily.getDailyId());
         }
     }
 

--- a/src/main/java/com/antk7894/amatda/service/DailyService.java
+++ b/src/main/java/com/antk7894/amatda/service/DailyService.java
@@ -13,6 +13,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.NoSuchElementException;
+
 @Service
 @Transactional
 @RequiredArgsConstructor
@@ -73,8 +75,7 @@ public class DailyService {
     private void checkAuth(Daily daily) {
         Planner planner = securityService.getCurrentUser();
         if (!planner.getRole().equals(UserRole.ADMIN) && !planner.hasSameId(daily.getPlanner())) {
-            throw new RuntimeException("권한 없음");
-            // TODO 글로벌 예외 처리
+            throw new NoSuchElementException();
         }
     }
 

--- a/src/main/java/com/antk7894/amatda/service/ScheduleService.java
+++ b/src/main/java/com/antk7894/amatda/service/ScheduleService.java
@@ -13,6 +13,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.NoSuchElementException;
+
 @Service
 @Transactional
 @RequiredArgsConstructor
@@ -59,8 +61,7 @@ public class ScheduleService {
     private void checkAuth(Schedule schedule) {
         Planner planner = securityService.getCurrentUser();
         if (!planner.getRole().equals(UserRole.ADMIN) && !planner.hasSameId(schedule.getPlanner())) {
-            throw new RuntimeException("권한 없음");
-            // TODO 글로벌 예외 처리
+            throw new NoSuchElementException();
         }
     }
 

--- a/src/main/java/com/antk7894/amatda/service/ScheduleService.java
+++ b/src/main/java/com/antk7894/amatda/service/ScheduleService.java
@@ -5,6 +5,7 @@ import com.antk7894.amatda.dto.schedule.request.ScheduleUpdateDto;
 import com.antk7894.amatda.entity.Schedule;
 import com.antk7894.amatda.entity.planner.Planner;
 import com.antk7894.amatda.entity.planner.UserRole;
+import com.antk7894.amatda.exception.custom.NoAuthenticationException;
 import com.antk7894.amatda.repository.ScheduleRepository;
 import com.antk7894.amatda.util.SecurityService;
 import lombok.RequiredArgsConstructor;
@@ -12,8 +13,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.NoSuchElementException;
 
 @Service
 @Transactional
@@ -61,7 +60,7 @@ public class ScheduleService {
     private void checkAuth(Schedule schedule) {
         Planner planner = securityService.getCurrentUser();
         if (!planner.getRole().equals(UserRole.ADMIN) && !planner.hasSameId(schedule.getPlanner())) {
-            throw new NoSuchElementException();
+            throw new NoAuthenticationException(planner.getPlannerId(), schedule.getClass().getSimpleName(), schedule.getScheduleId());
         }
     }
 

--- a/src/main/java/com/antk7894/amatda/service/TaskService.java
+++ b/src/main/java/com/antk7894/amatda/service/TaskService.java
@@ -13,6 +13,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.NoSuchElementException;
+
 @Service
 @Transactional
 @RequiredArgsConstructor
@@ -73,8 +75,7 @@ public class TaskService {
     private void checkAuth(Task task) {
         Planner planner = securityService.getCurrentUser();
         if (!planner.getRole().equals(UserRole.ADMIN) && !planner.hasSameId(task.getPlanner())) {
-            throw new RuntimeException("권한 없음");
-            // TODO 글로벌 예외 처리
+            throw new NoSuchElementException();
         }
     }
 

--- a/src/main/java/com/antk7894/amatda/service/TaskService.java
+++ b/src/main/java/com/antk7894/amatda/service/TaskService.java
@@ -5,6 +5,7 @@ import com.antk7894.amatda.dto.task.request.TaskUpdateDto;
 import com.antk7894.amatda.entity.Task;
 import com.antk7894.amatda.entity.planner.Planner;
 import com.antk7894.amatda.entity.planner.UserRole;
+import com.antk7894.amatda.exception.custom.NoAuthenticationException;
 import com.antk7894.amatda.repository.TaskRepository;
 import com.antk7894.amatda.util.SecurityService;
 import lombok.RequiredArgsConstructor;
@@ -12,8 +13,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.NoSuchElementException;
 
 @Service
 @Transactional
@@ -75,7 +74,7 @@ public class TaskService {
     private void checkAuth(Task task) {
         Planner planner = securityService.getCurrentUser();
         if (!planner.getRole().equals(UserRole.ADMIN) && !planner.hasSameId(task.getPlanner())) {
-            throw new NoSuchElementException();
+            throw new NoAuthenticationException(planner.getPlannerId(), task.getClass().getSimpleName(), task.getTaskId());
         }
     }
 


### PR DESCRIPTION
`@RestControllerAdvice` 활용하여 글로벌 예외 처리 핸들러를 구현하였음

현재 서버 내 발생하는 예외는 다음과 같음
- 유효하지 않은 입력값(`@valid` 통해 필터에서 처리됨)
- 존재하지 않는 자원에 대한 조회(완료)
- 권한이 없는 자원에 대한 접근(완료)

This Closes #15 