### PR TITLE
사용자 요청 처리 로깅 구현

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -18,6 +18,7 @@ env:
   DB_USERNAME: root
   DB_PASSWORD: root
   DDL_OPTION: create
+  SHOW_SQL: false
   JWT_SECRET: ${{ secrets.JWT_SECRET }} 
 
 permissions:

--- a/src/main/java/com/antk7894/amatda/AmatdaApplication.java
+++ b/src/main/java/com/antk7894/amatda/AmatdaApplication.java
@@ -2,10 +2,12 @@ package com.antk7894.amatda;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.EnableAspectJAutoProxy;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @EnableJpaAuditing
 @SpringBootApplication
+@EnableAspectJAutoProxy
 public class AmatdaApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/antk7894/amatda/aspect/LogAspect.java
+++ b/src/main/java/com/antk7894/amatda/aspect/LogAspect.java
@@ -1,0 +1,31 @@
+package com.antk7894.amatda.aspect;
+
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.*;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Aspect
+@Component
+public class LogAspect {
+
+    @Pointcut("within(com.antk7894.amatda.controller.*)")
+    private void controllerPoint() {}
+
+    @Before("controllerPoint()")
+    public void logRequestDto(JoinPoint joinPoint) {
+        log.info("[Request] method:{} body:{}", joinPoint.getSignature().toShortString(), joinPoint.getArgs());
+    }
+
+    @AfterReturning(pointcut = "controllerPoint()", returning = "returnValue")
+    public void logResponseDto(JoinPoint joinPoint, Object returnValue) {
+        log.info("[Response] method:{} body{}", joinPoint.getSignature().toShortString(), returnValue);
+    }
+
+    @AfterThrowing(pointcut = "controllerPoint()", throwing = "exception")
+    public void logException(JoinPoint joinPoint, Exception exception) {
+        log.error("[Error] method:{} message:{}", joinPoint.getSignature().toShortString(), exception.getMessage());
+    }
+
+}

--- a/src/main/java/com/antk7894/amatda/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/antk7894/amatda/exception/GlobalExceptionHandler.java
@@ -18,7 +18,6 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(NoAuthenticationException.class)
     public ResponseEntity<?> noAuthenticationHandle(NoAuthenticationException exception) {
-        System.out.println(exception.getMessage());
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(null);
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,7 +11,7 @@ spring:
     properties:
       hibernate:
         default_batch_fetch_size: 100
-        show_sql: true
+        show_sql: ${SHOW_SQL}
         format_sql: true
 
 jwt:


### PR DESCRIPTION
## 사용자의 요청에 대한 로그 처리 `Spring AOP` 활용하여 구현

<br/>

로그가 출력 되는 시점 및 내용은 다음과 같음
- **사용자 요청 시**: 메서드 이름, 요청 DTO
- **사용자 요청에 대한 응답 시**: 메서드 이름, 응답 DTO, 상태 코드
- **사용자 요청 처리 중 예외 발생 시**: 메서드 이름, 에러 메세지

<br/>


출력 예시

```
2023-09-24T20:56:13.660+09:00  INFO 9616 --- [nio-8080-exec-2] com.antk7894.amatda.aspect.LogAspect     : [Request] method:DailyController.all(..) body:[Page request [number: 0, size 20, sort: UNSORTED]]
2023-09-24T20:56:13.666+09:00  INFO 9616 --- [nio-8080-exec-2] com.antk7894.amatda.aspect.LogAspect     : [Response] method:DailyController.all(..) body<200 OK OK,Page 1 of 1 containing com.antk7894.amatda.dto.daily.response.DailyInquireDto instances,[]>
2023-09-24T20:56:24.373+09:00  WARN 9616 --- [nio-8080-exec-8] ocalVariableTableParameterNameDiscoverer : Using deprecated '-debug' fallback for parameter name resolution. Compile the affected code with '-parameters' instead or avoid its introspection: com.antk7894.amatda.controller.DailyController
2023-09-24T20:56:24.374+09:00  INFO 9616 --- [nio-8080-exec-8] com.antk7894.amatda.aspect.LogAspect     : [Request] method:DailyController.one(..) body:[1]
2023-09-24T20:56:24.395+09:00  INFO 9616 --- [nio-8080-exec-8] com.antk7894.amatda.aspect.LogAspect     : [Response] method:DailyController.one(..) body<200 OK OK,DailyInquireDto[dailyId=1, title=출근 하기, description=출근 하기, isFinished=false],[]>
2023-09-24T20:56:32.445+09:00  INFO 9616 --- [nio-8080-exec-6] com.antk7894.amatda.aspect.LogAspect     : [Request] method:PlannerController.newPlanner(..) body:[PlannerJoinDto[email=antk7895@naver.com, password=dksxodnr9, role=user]]
2023-09-24T20:56:32.528+09:00  INFO 9616 --- [nio-8080-exec-6] com.antk7894.amatda.aspect.LogAspect     : [Response] method:PlannerController.newPlanner(..) body<201 CREATED Created,PlannerInquireDto[plannerId=2, email=antk7895@naver.com, role=USER],[Location:"http://localhost:8080/api/planners/2"]>
2023-09-24T20:56:43.370+09:00  INFO 9616 --- [io-8080-exec-10] com.antk7894.amatda.aspect.LogAspect     : [Request] method:PlannerController.login(..) body:[PlannerLoginDto[email=antk7895@naver.com, password=dksxodnr9]]
2023-09-24T20:56:43.448+09:00  INFO 9616 --- [io-8080-exec-10] com.antk7894.amatda.aspect.LogAspect     : [Response] method:PlannerController.login(..) body<200 OK OK,TokenInfo[grantType=Bearer, accessToken=eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhbnRrNzg5NUBuYXZlci5jb20iLCJhdXRoIjoiUk9MRV9VU0VSIiwiZXhwIjoxNjk1NTYzODAzfQ.BWUj8M9t7Vovvw1sQy0Bfqv5DAdOjVWFyZ4jdJsA-i0],[]>
2023-09-24T20:56:55.813+09:00  INFO 9616 --- [nio-8080-exec-4] com.antk7894.amatda.aspect.LogAspect     : [Request] method:DailyController.all(..) body:[Page request [number: 0, size 20, sort: UNSORTED]]
2023-09-24T20:56:55.821+09:00  INFO 9616 --- [nio-8080-exec-4] com.antk7894.amatda.aspect.LogAspect     : [Response] method:DailyController.all(..) body<200 OK OK,Page 1 of 0 containing UNKNOWN instances,[]>
2023-09-24T20:56:59.712+09:00  INFO 9616 --- [nio-8080-exec-1] com.antk7894.amatda.aspect.LogAspect     : [Request] method:DailyController.one(..) body:[1]
2023-09-24T20:56:59.719+09:00 ERROR 9616 --- [nio-8080-exec-1] com.antk7894.amatda.aspect.LogAspect     : [Error] method:DailyController.one(..) message:user id=2 has no authentication about this resource: Daily id=1
```

This Closes #16 