### PR TITLE
일일 작업 조회 버그 수정

### DIFF
--- a/src/main/java/com/antk7894/amatda/dto/daily/response/DailyInquireDto.java
+++ b/src/main/java/com/antk7894/amatda/dto/daily/response/DailyInquireDto.java
@@ -11,7 +11,7 @@ public record DailyInquireDto(
 
     public static DailyInquireDto from(Daily daily) {
         return new DailyInquireDto(
-                daily.getDailyId(), daily.getTitle(), daily.getTitle(), daily.isFinished()
+                daily.getDailyId(), daily.getTitle(), daily.getDescription(), daily.isFinished()
         );
     }
 

--- a/src/main/java/com/antk7894/amatda/dto/planner/response/PlannerInquireDto.java
+++ b/src/main/java/com/antk7894/amatda/dto/planner/response/PlannerInquireDto.java
@@ -1,7 +1,6 @@
 package com.antk7894.amatda.dto.planner.response;
 
 import com.antk7894.amatda.entity.planner.Planner;
-import com.antk7894.amatda.entity.planner.UserRole;
 
 public record PlannerInquireDto(
         Long plannerId,


### PR DESCRIPTION
일일 작업 조회 시, 설명 부분 내 제목이 중복 되어 들어가는 버그를 수정하였음.

지난 사용자 로깅 구현#18 작업 내 로그에 의해 알게 되었음

<br/>

수정 전

```
2023-09-24T20:56:24.395+09:00  INFO 9616 --- [nio-8080-exec-8] com.antk7894.amatda.aspect.LogAspect     : [Response] method:DailyController.one(..) body<200 OK OK,DailyInquireDto[dailyId=1, title=출근 하기, description=출근 하기, isFinished=false],[]>
```

수정 후

```
2023-09-24T21:07:50.440+09:00  INFO 2504 --- [nio-8080-exec-3] com.antk7894.amatda.aspect.LogAspect     : [Response] method:DailyController.one(..) body<200 OK OK,DailyInquireDto[dailyId=1, title=출근 하기, description=출근 해서 즐겁게 일하자, isFinished=false],[]>
```

