### PR TITLE
서비스 계층 테스트 코드 작성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,9 +40,20 @@ dependencies {
 	// validation
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 
-	compileOnly 'org.projectlombok:lombok'
+	// DB
 	runtimeOnly 'com.mysql:mysql-connector-j'
+
+	// testDB
+	runtimeOnly 'com.h2database:h2'
+
+	// mocking
+	testImplementation 'org.mockito:mockito-core:4.8.0'
+
+	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
+
+	testCompileOnly 'org.projectlombok:lombok'
+	testAnnotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 

--- a/src/main/java/com/antk7894/amatda/service/DailyService.java
+++ b/src/main/java/com/antk7894/amatda/service/DailyService.java
@@ -7,7 +7,6 @@ import com.antk7894.amatda.entity.planner.Planner;
 import com.antk7894.amatda.entity.planner.UserRole;
 import com.antk7894.amatda.exception.custom.NoAuthenticationException;
 import com.antk7894.amatda.repository.DailyRepository;
-import com.antk7894.amatda.util.SecurityService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;

--- a/src/main/java/com/antk7894/amatda/service/ScheduleService.java
+++ b/src/main/java/com/antk7894/amatda/service/ScheduleService.java
@@ -7,7 +7,6 @@ import com.antk7894.amatda.entity.planner.Planner;
 import com.antk7894.amatda.entity.planner.UserRole;
 import com.antk7894.amatda.exception.custom.NoAuthenticationException;
 import com.antk7894.amatda.repository.ScheduleRepository;
-import com.antk7894.amatda.util.SecurityService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;

--- a/src/main/java/com/antk7894/amatda/service/SecurityService.java
+++ b/src/main/java/com/antk7894/amatda/service/SecurityService.java
@@ -1,7 +1,6 @@
-package com.antk7894.amatda.util;
+package com.antk7894.amatda.service;
 
 import com.antk7894.amatda.entity.planner.Planner;
-import com.antk7894.amatda.service.PlannerService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;

--- a/src/main/java/com/antk7894/amatda/service/TaskService.java
+++ b/src/main/java/com/antk7894/amatda/service/TaskService.java
@@ -7,7 +7,6 @@ import com.antk7894.amatda.entity.planner.Planner;
 import com.antk7894.amatda.entity.planner.UserRole;
 import com.antk7894.amatda.exception.custom.NoAuthenticationException;
 import com.antk7894.amatda.repository.TaskRepository;
-import com.antk7894.amatda.util.SecurityService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;

--- a/src/test/java/com/antk7894/amatda/service/DailyServiceTest.java
+++ b/src/test/java/com/antk7894/amatda/service/DailyServiceTest.java
@@ -1,0 +1,215 @@
+package com.antk7894.amatda.service;
+
+import com.antk7894.amatda.dto.daily.request.DailyCreateDto;
+import com.antk7894.amatda.dto.daily.request.DailyUpdateDto;
+import com.antk7894.amatda.entity.Daily;
+import com.antk7894.amatda.entity.planner.Planner;
+import com.antk7894.amatda.entity.planner.UserRole;
+import com.antk7894.amatda.exception.custom.NoAuthenticationException;
+import com.antk7894.amatda.repository.DailyRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class DailyServiceTest {
+
+    @Mock
+    private DailyRepository dailyRepository;
+
+    @Mock
+    private SecurityService securityService;
+
+    @InjectMocks
+    private DailyService dailyService;
+
+    @Test
+    @DisplayName("관리자 - 모든 일일 작업을 조회한다")
+    void findAllFromAdmin() {
+        // given
+        Planner planner = new Planner("email", "password", UserRole.ADMIN);
+        Daily daily = new Daily(planner, "title", "desc", false);
+        given(dailyRepository.findAll(any(Pageable.class))).willReturn(new PageImpl<>(List.of(daily)));
+        given(securityService.getCurrentUser()).willReturn(planner);
+
+        // when
+        Page<Daily> dailyPage = dailyService.findAll(Pageable.ofSize(10));
+
+        // then
+        assertThat(dailyPage.getTotalElements()).isEqualTo(1);
+        verify(dailyRepository, times(1)).findAll(any(Pageable.class));
+    }
+
+    @Test
+    @DisplayName("사용자 - 모든 일일 작업을 조회한다")
+    void findAllFromUser() {
+        // given
+        Planner planner = new Planner("email", "password", UserRole.USER);
+        Daily daily = new Daily(planner, "title", "desc", false);
+        given(dailyRepository.findByPlanner(any(Planner.class), any(Pageable.class))).willReturn(new PageImpl<>(List.of(daily)));
+        given(securityService.getCurrentUser()).willReturn(planner);
+
+        // when
+        Page<Daily> dailyPage = dailyService.findAll(Pageable.ofSize(10));
+
+        // then
+        assertThat(dailyPage.getTotalElements()).isEqualTo(1);
+        verify(dailyRepository, times(1)).findByPlanner(any(), any());
+    }
+
+    @Test
+    @DisplayName("ID를 통해 단일 일일 작업을 조회한다")
+    void findOneById() {
+        // given
+        Planner plannerMock = mock(Planner.class);
+        given(plannerMock.hasSameId(any())).willReturn(true);
+        given(plannerMock.getRole()).willReturn(UserRole.USER);
+
+        Daily dailyMock = mock(Daily.class);
+        given(dailyMock.getTitle()).willReturn("title");
+
+
+        given(dailyRepository.findById(any(Long.class))).willReturn(Optional.of(dailyMock));
+        given(securityService.getCurrentUser()).willReturn(plannerMock);
+
+        // when
+        Daily founded = dailyService.findOneById(1L);
+
+        // then
+        assertThat(founded.getTitle()).isEqualTo("title");
+        verify(dailyRepository, times(1)).findById(any());
+    }
+
+    @Test
+    @DisplayName("단일 일일 작업을 저장한다")
+    void saveOne() {
+        // given
+        Daily dailyMock = mock(Daily.class);
+        given(dailyMock.getTitle()).willReturn("title");
+        given(dailyRepository.save(any(Daily.class))).willReturn(dailyMock);
+
+        // when
+        Daily daily = dailyService.saveOne(new DailyCreateDto("title", "desc"));
+
+        // then
+        assertThat(daily.getTitle()).isEqualTo("title");
+        verify(dailyRepository, times(1)).save(any());
+    }
+
+    @Test
+    @DisplayName("단일 일일 작업의 내용을 수정한다")
+    void updateOne() {
+        // given
+        Planner plannerMock = mock(Planner.class);
+        given(plannerMock.hasSameId(any())).willReturn(true);
+        given(plannerMock.getRole()).willReturn(UserRole.USER);
+
+        Daily dailyMock = mock(Daily.class);
+
+        given(dailyRepository.findById(any(Long.class))).willReturn(Optional.of(dailyMock));
+        given(securityService.getCurrentUser()).willReturn(plannerMock);
+
+        // when
+        dailyService.updateOne(1L, new DailyUpdateDto("new title", "update daily"));
+
+        // then
+        verify(dailyRepository, times(1)).findById(any());
+        verify(dailyMock, times(1)).updateTitleAndDescription(any(), any());
+    }
+
+    @Test
+    @DisplayName("단일 일일 작업의 상태를 \"수행 완료\"로 수정한다")
+    void finishOne() {
+        // given
+        Planner plannerMock = mock(Planner.class);
+        given(plannerMock.hasSameId(any())).willReturn(true);
+        given(plannerMock.getRole()).willReturn(UserRole.USER);
+
+        Daily dailyMock = mock(Daily.class);
+
+        given(dailyRepository.findById(any(Long.class))).willReturn(Optional.of(dailyMock));
+        given(securityService.getCurrentUser()).willReturn(plannerMock);
+
+        // when
+        dailyService.finishOne(1L);
+
+        // then
+        verify(dailyRepository, times(1)).findById(any());
+        verify(dailyMock, times(1)).setFinished(true);
+    }
+
+    @Test
+    @DisplayName("단일 일일 작업의 상태를 \"미수행\"로 수정한다")
+    void resetOne() {
+        // given
+        Planner plannerMock = mock(Planner.class);
+        given(plannerMock.hasSameId(any())).willReturn(true);
+        given(plannerMock.getRole()).willReturn(UserRole.USER);
+
+        Daily dailyMock = mock(Daily.class);
+
+        given(dailyRepository.findById(any(Long.class))).willReturn(Optional.of(dailyMock));
+        given(securityService.getCurrentUser()).willReturn(plannerMock);
+
+        // when
+        dailyService.resetOne(1L);
+
+        // then
+        verify(dailyRepository, times(1)).findById(any());
+        verify(dailyMock, times(1)).setFinished(false);
+    }
+
+    @Test
+    @DisplayName("단일 일일 작업을 삭제한다")
+    void removeOne() {
+        // given
+        Planner plannerMock = mock(Planner.class);
+        given(plannerMock.hasSameId(any())).willReturn(true);
+        given(plannerMock.getRole()).willReturn(UserRole.USER);
+
+        Daily dailyMock = mock(Daily.class);
+
+        given(dailyRepository.findById(any(Long.class))).willReturn(Optional.of(dailyMock));
+        given(securityService.getCurrentUser()).willReturn(plannerMock);
+
+        // when
+        dailyService.removeOne(1L);
+
+        // then
+        verify(dailyRepository, times(1)).findById(any());
+        verify(dailyRepository, times(1)).delete(any());
+    }
+
+    @Test
+    @DisplayName("권한히 없는 일일 작업에 접근할 경우 NoAuthenticationException 예외를 발생시킨다")
+    void hasNoAuthentication() {
+        // given
+        Planner plannerMock = mock(Planner.class);
+        given(plannerMock.hasSameId(any())).willReturn(false);
+        given(plannerMock.getRole()).willReturn(UserRole.USER);
+
+        Daily dailyMock = mock(Daily.class);
+
+        given(dailyRepository.findById(any(Long.class))).willReturn(Optional.of(dailyMock));
+        given(securityService.getCurrentUser()).willReturn(plannerMock);
+
+        // when & then
+        assertThatThrownBy(() -> dailyService.findOneById(1L))
+                .isExactlyInstanceOf(NoAuthenticationException.class);
+    }
+
+}

--- a/src/test/java/com/antk7894/amatda/service/PlannerServiceTest.java
+++ b/src/test/java/com/antk7894/amatda/service/PlannerServiceTest.java
@@ -1,0 +1,127 @@
+package com.antk7894.amatda.service;
+
+import com.antk7894.amatda.dto.planner.request.PlannerJoinDto;
+import com.antk7894.amatda.dto.planner.request.PlannerLoginDto;
+import com.antk7894.amatda.entity.planner.Planner;
+import com.antk7894.amatda.entity.planner.UserRole;
+import com.antk7894.amatda.repository.PlannerRepository;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.NoSuchElementException;
+
+import static org.assertj.core.api.Assertions.*;
+
+@SpringBootTest
+class PlannerServiceTest {
+
+    @Autowired
+    private PlannerService plannerService;
+
+    @Autowired
+    private PlannerRepository plannerRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @BeforeEach
+    void setUp() {
+        plannerRepository.save(new Planner("email1", passwordEncoder.encode("password"), UserRole.USER));
+        plannerRepository.save(new Planner("email2", passwordEncoder.encode("password"), UserRole.USER));
+        plannerRepository.save(new Planner("email3", passwordEncoder.encode("password"), UserRole.USER));
+    }
+
+    @AfterEach
+    void tearDown() {
+        plannerRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("모든 사용자를 조회한다")
+    void findAll() {
+        // given & when
+        Page<Planner> planners = plannerService.findAll(Pageable.ofSize(10));
+
+        // then
+        assertThat(planners.getTotalElements()).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("ID를 통해 단일 사용자를 조회한다")
+    void findOneById() {
+        // given
+        Planner planner = plannerRepository.save(new Planner("email", "password", UserRole.USER));
+
+        // when
+        Planner founded = plannerService.findOneById(planner.getPlannerId());
+
+        // then
+        assertThat(founded.getPlannerId()).isEqualTo(planner.getPlannerId());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 ID를 통해 조회할 경우 NoSuchElementException 예외를 던진다")
+    void findOneByIdFail() {
+        assertThatThrownBy(() -> plannerService.findOneById(-1L))
+                .isExactlyInstanceOf(NoSuchElementException.class);
+    }
+
+    @Test
+    @DisplayName("이메일을 통해 단일 사용자를 조회한다")
+    void findOneByEmail() {
+        // given
+        Planner planner = plannerRepository.save(new Planner("email", "password", UserRole.USER));
+
+        // when
+        Planner founded = plannerService.findOneByEmail(planner.getEmail());
+
+        // then
+        assertThat(founded.getEmail()).isEqualTo(planner.getEmail());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 이메일을 통해 조회할 경우 NoSuchElementException 예외를 던진다")
+    void findOneByEmailFail() {
+        assertThatThrownBy(() -> plannerService.findOneByEmail("IvalidEmail"))
+                .isExactlyInstanceOf(NoSuchElementException.class);
+    }
+
+    @Test
+    @DisplayName("단일 사용자를 저장한다")
+    void saveOne() {
+        // given
+        Planner planner = plannerService.saveOne(new PlannerJoinDto("email", "password", "USER"));
+
+        // when
+        Planner founded = plannerRepository.findByEmail(planner.getEmail()).orElseThrow();
+
+        // then
+        assertThat(founded.getPlannerId()).isEqualTo(planner.getPlannerId());
+    }
+
+    @Test
+    @DisplayName("단일 사용자를 삭제한다")
+    void removeOne() {
+        // given
+        Planner planner = plannerService.findOneByEmail("email1");
+
+        // when
+        plannerService.removeOne(planner.getPlannerId());
+        Page<Planner> planners = plannerService.findAll(Pageable.ofSize(10));
+
+        // then
+        assertThat(planners.getTotalElements()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("사용자의 정보를 통해 로그인을 한다")
+    void login() {
+        assertThatCode(() -> plannerService.login(new PlannerLoginDto("email1", "password")))
+                .doesNotThrowAnyException();
+    }
+
+}

--- a/src/test/java/com/antk7894/amatda/service/ScheduleServiceTest.java
+++ b/src/test/java/com/antk7894/amatda/service/ScheduleServiceTest.java
@@ -1,0 +1,178 @@
+package com.antk7894.amatda.service;
+
+import com.antk7894.amatda.dto.schedule.request.ScheduleCreateDto;
+import com.antk7894.amatda.dto.schedule.request.ScheduleUpdateDto;
+import com.antk7894.amatda.dto.schedule.request.ScheduleCreateDto;
+import com.antk7894.amatda.dto.schedule.request.ScheduleUpdateDto;
+import com.antk7894.amatda.entity.Schedule;
+import com.antk7894.amatda.entity.Schedule;
+import com.antk7894.amatda.entity.planner.Planner;
+import com.antk7894.amatda.entity.planner.UserRole;
+import com.antk7894.amatda.exception.custom.NoAuthenticationException;
+import com.antk7894.amatda.repository.ScheduleRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+
+@ExtendWith(MockitoExtension.class)
+class ScheduleServiceTest {
+
+    @Mock
+    private ScheduleRepository scheduleRepository;
+
+    @Mock
+    private SecurityService securityService;
+
+    @InjectMocks
+    private ScheduleService scheduleService;
+
+    @Test
+    @DisplayName("관리자 - 모든 일정을 조회한다")
+    void findAllForAdmin() {
+        // given
+        Planner planner = new Planner("email", "password", UserRole.ADMIN);
+        Schedule schedule = new Schedule(planner, "title", "desc", LocalDateTime.now());
+        given(scheduleRepository.findAll(any(Pageable.class))).willReturn(new PageImpl<>(List.of(schedule)));
+        given(securityService.getCurrentUser()).willReturn(planner);
+
+        // when
+        Page<Schedule> schedulePage = scheduleService.findAll(Pageable.ofSize(10));
+
+        // then
+        assertThat(schedulePage.getTotalElements()).isEqualTo(1);
+        verify(scheduleRepository, times(1)).findAll(any(Pageable.class));
+    }
+
+    @Test
+    @DisplayName("사용자 - 모든 일정을 조회한다")
+    void findAllForUser() {
+        // given
+        Planner planner = new Planner("email", "password", UserRole.USER);
+        Schedule schedule = new Schedule(planner, "title", "desc", LocalDateTime.now());
+        given(scheduleRepository.findByPlanner(any(Planner.class), any(Pageable.class))).willReturn(new PageImpl<>(List.of(schedule)));
+        given(securityService.getCurrentUser()).willReturn(planner);
+
+        // when
+        Page<Schedule> schedulePage = scheduleService.findAll(Pageable.ofSize(10));
+
+        // then
+        assertThat(schedulePage.getTotalElements()).isEqualTo(1);
+        verify(scheduleRepository, times(1)).findByPlanner(any(), any());
+    }
+
+    @Test
+    @DisplayName("ID를 통해 단일 일정을 조회한다")
+    void findOneById() {
+        // given
+        Planner plannerMock = mock(Planner.class);
+        given(plannerMock.hasSameId(any())).willReturn(true);
+        given(plannerMock.getRole()).willReturn(UserRole.USER);
+
+        Schedule scheduleMock = mock(Schedule.class);
+        given(scheduleMock.getTitle()).willReturn("title");
+
+
+        given(scheduleRepository.findById(any(Long.class))).willReturn(Optional.of(scheduleMock));
+        given(securityService.getCurrentUser()).willReturn(plannerMock);
+
+        // when
+        Schedule founded = scheduleService.findOneById(1L);
+
+        // then
+        assertThat(founded.getTitle()).isEqualTo("title");
+        verify(scheduleRepository, times(1)).findById(any());
+    }
+
+    @Test
+    @DisplayName("단일 일정을 저장한다")
+    void saveOne() {
+        // given
+        Schedule scheduleMock = mock(Schedule.class);
+        given(scheduleMock.getTitle()).willReturn("title");
+        given(scheduleRepository.save(any(Schedule.class))).willReturn(scheduleMock);
+
+        // when
+        Schedule schedule = scheduleService.saveOne(new ScheduleCreateDto("title", "desc", LocalDateTime.now()));
+
+        // then
+        assertThat(schedule.getTitle()).isEqualTo("title");
+        verify(scheduleRepository, times(1)).save(any());
+    }
+
+    @Test
+    @DisplayName("단일 일정의 내용을 수정한다")
+    void updateOne() {
+        // given
+        Planner plannerMock = mock(Planner.class);
+        given(plannerMock.hasSameId(any())).willReturn(true);
+        given(plannerMock.getRole()).willReturn(UserRole.USER);
+
+        Schedule scheduleMock = mock(Schedule.class);
+
+        given(scheduleRepository.findById(any(Long.class))).willReturn(Optional.of(scheduleMock));
+        given(securityService.getCurrentUser()).willReturn(plannerMock);
+
+        // when
+        scheduleService.updateOne(1L, new ScheduleUpdateDto("new title", "update schedule", LocalDateTime.now()));
+
+        // then
+        verify(scheduleRepository, times(1)).findById(any());
+        verify(scheduleMock, times(1)).updateSchedule(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("단일 일정을 삭제한다")
+    void removeOne() {
+        // given
+        Planner plannerMock = mock(Planner.class);
+        given(plannerMock.hasSameId(any())).willReturn(true);
+        given(plannerMock.getRole()).willReturn(UserRole.USER);
+
+        Schedule scheduleMock = mock(Schedule.class);
+
+        given(scheduleRepository.findById(any(Long.class))).willReturn(Optional.of(scheduleMock));
+        given(securityService.getCurrentUser()).willReturn(plannerMock);
+
+        // when
+        scheduleService.removeOne(1L);
+
+        // then
+        verify(scheduleRepository, times(1)).findById(any());
+        verify(scheduleRepository, times(1)).delete(any());
+    }
+
+    @Test
+    @DisplayName("권한히 없는 일정에 접근할 경우 NoAuthenticationException 예외를 발생시킨다")
+    void hasNoAuthentication() {
+        // given
+        Planner plannerMock = mock(Planner.class);
+        given(plannerMock.hasSameId(any())).willReturn(false);
+        given(plannerMock.getRole()).willReturn(UserRole.USER);
+
+        Schedule scheduleMock = mock(Schedule.class);
+
+        given(scheduleRepository.findById(any(Long.class))).willReturn(Optional.of(scheduleMock));
+        given(securityService.getCurrentUser()).willReturn(plannerMock);
+
+        // when & then
+        assertThatThrownBy(() -> scheduleService.findOneById(1L))
+                .isExactlyInstanceOf(NoAuthenticationException.class);
+    }
+    
+}

--- a/src/test/java/com/antk7894/amatda/service/TaskServiceTest.java
+++ b/src/test/java/com/antk7894/amatda/service/TaskServiceTest.java
@@ -1,0 +1,217 @@
+package com.antk7894.amatda.service;
+
+import com.antk7894.amatda.dto.task.request.TaskCreateDto;
+import com.antk7894.amatda.dto.task.request.TaskUpdateDto;
+import com.antk7894.amatda.entity.Task;
+import com.antk7894.amatda.entity.planner.Planner;
+import com.antk7894.amatda.entity.planner.UserRole;
+import com.antk7894.amatda.exception.custom.NoAuthenticationException;
+import com.antk7894.amatda.repository.TaskRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+
+@ExtendWith(MockitoExtension.class)
+class TaskServiceTest {
+
+    @Mock
+    private TaskRepository taskRepository;
+
+    @Mock
+    private SecurityService securityService;
+
+    @InjectMocks
+    private TaskService taskService;
+
+    @Test
+    @DisplayName("관리자 - 모든 업무를 조회한다")
+    void findAllFromAdmin() {
+        // given
+        Planner planner = new Planner("email", "password", UserRole.ADMIN);
+        Task task = new Task(planner, "title", "desc", false, LocalDateTime.now());
+        given(taskRepository.findAll(any(Pageable.class))).willReturn(new PageImpl<>(List.of(task)));
+        given(securityService.getCurrentUser()).willReturn(planner);
+
+        // when
+        Page<Task> taskPage = taskService.findAll(Pageable.ofSize(10));
+
+        // then
+        assertThat(taskPage.getTotalElements()).isEqualTo(1);
+        verify(taskRepository, times(1)).findAll(any(Pageable.class));
+    }
+
+    @Test
+    @DisplayName("사용자 - 모든 업무를 조회한다")
+    void findAllFromUser() {
+        // given
+        Planner planner = new Planner("email", "password", UserRole.USER);
+        Task task = new Task(planner, "title", "desc", false, LocalDateTime.now());
+        given(taskRepository.findByPlanner(any(Planner.class), any(Pageable.class))).willReturn(new PageImpl<>(List.of(task)));
+        given(securityService.getCurrentUser()).willReturn(planner);
+
+        // when
+        Page<Task> taskPage = taskService.findAll(Pageable.ofSize(10));
+
+        // then
+        assertThat(taskPage.getTotalElements()).isEqualTo(1);
+        verify(taskRepository, times(1)).findByPlanner(any(), any());
+    }
+
+    @Test
+    @DisplayName("ID를 통해 단일 업무를 조회한다")
+    void findOneById() {
+        // given
+        Planner plannerMock = mock(Planner.class);
+        given(plannerMock.hasSameId(any())).willReturn(true);
+        given(plannerMock.getRole()).willReturn(UserRole.USER);
+
+        Task taskMock = mock(Task.class);
+        given(taskMock.getTitle()).willReturn("title");
+
+
+        given(taskRepository.findById(any(Long.class))).willReturn(Optional.of(taskMock));
+        given(securityService.getCurrentUser()).willReturn(plannerMock);
+
+        // when
+        Task founded = taskService.findOneById(1L);
+
+        // then
+        assertThat(founded.getTitle()).isEqualTo("title");
+        verify(taskRepository, times(1)).findById(any());
+    }
+
+    @Test
+    @DisplayName("단일 업무를 저장한다")
+    void saveOne() {
+        // given
+        Task taskMock = mock(Task.class);
+        given(taskMock.getTitle()).willReturn("title");
+        given(taskRepository.save(any(Task.class))).willReturn(taskMock);
+
+        // when
+        Task task = taskService.saveOne(new TaskCreateDto("title", "desc", LocalDateTime.now()));
+
+        // then
+        assertThat(task.getTitle()).isEqualTo("title");
+        verify(taskRepository, times(1)).save(any());
+    }
+
+    @Test
+    @DisplayName("단일 업무의 내용을 수정한다")
+    void updateOne() {
+        // given
+        Planner plannerMock = mock(Planner.class);
+        given(plannerMock.hasSameId(any())).willReturn(true);
+        given(plannerMock.getRole()).willReturn(UserRole.USER);
+
+        Task taskMock = mock(Task.class);
+
+        given(taskRepository.findById(any(Long.class))).willReturn(Optional.of(taskMock));
+        given(securityService.getCurrentUser()).willReturn(plannerMock);
+
+        // when
+        taskService.updateOne(1L, new TaskUpdateDto("new title", "update task", LocalDateTime.now()));
+
+        // then
+        verify(taskRepository, times(1)).findById(any());
+        verify(taskMock, times(1)).updateTask(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("단일 업무의 상태를 \"수행 완료\"로 수정한다")
+    void finishOne() {
+        // given
+        Planner plannerMock = mock(Planner.class);
+        given(plannerMock.hasSameId(any())).willReturn(true);
+        given(plannerMock.getRole()).willReturn(UserRole.USER);
+
+        Task taskMock = mock(Task.class);
+
+        given(taskRepository.findById(any(Long.class))).willReturn(Optional.of(taskMock));
+        given(securityService.getCurrentUser()).willReturn(plannerMock);
+
+        // when
+        taskService.finishOne(1L);
+
+        // then
+        verify(taskRepository, times(1)).findById(any());
+        verify(taskMock, times(1)).setFinished(true);
+    }
+
+    @Test
+    @DisplayName("단일 업무의 상태를 \"미수행\"로 수정한다")
+    void resetOne() {
+        // given
+        Planner plannerMock = mock(Planner.class);
+        given(plannerMock.hasSameId(any())).willReturn(true);
+        given(plannerMock.getRole()).willReturn(UserRole.USER);
+
+        Task taskMock = mock(Task.class);
+
+        given(taskRepository.findById(any(Long.class))).willReturn(Optional.of(taskMock));
+        given(securityService.getCurrentUser()).willReturn(plannerMock);
+
+        // when
+        taskService.resetOne(1L);
+
+        // then
+        verify(taskRepository, times(1)).findById(any());
+        verify(taskMock, times(1)).setFinished(false);
+    }
+
+    @Test
+    @DisplayName("단일 업무를 삭제한다")
+    void removeOne() {
+        // given
+        Planner plannerMock = mock(Planner.class);
+        given(plannerMock.hasSameId(any())).willReturn(true);
+        given(plannerMock.getRole()).willReturn(UserRole.USER);
+
+        Task taskMock = mock(Task.class);
+
+        given(taskRepository.findById(any(Long.class))).willReturn(Optional.of(taskMock));
+        given(securityService.getCurrentUser()).willReturn(plannerMock);
+
+        // when
+        taskService.removeOne(1L);
+
+        // then
+        verify(taskRepository, times(1)).findById(any());
+        verify(taskRepository, times(1)).delete(any());
+    }
+
+    @Test
+    @DisplayName("권한히 없는 업무에 접근할 경우 NoAuthenticationException 예외를 발생시킨다")
+    void hasNoAuthentication() {
+        // given
+        Planner plannerMock = mock(Planner.class);
+        given(plannerMock.hasSameId(any())).willReturn(false);
+        given(plannerMock.getRole()).willReturn(UserRole.USER);
+
+        Task taskMock = mock(Task.class);
+
+        given(taskRepository.findById(any(Long.class))).willReturn(Optional.of(taskMock));
+        given(securityService.getCurrentUser()).willReturn(plannerMock);
+
+        // when & then
+        assertThatThrownBy(() -> taskService.findOneById(1L))
+                .isExactlyInstanceOf(NoAuthenticationException.class);
+    }
+
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,11 @@
+spring:
+  datasource:
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:mem:testdb;MODE=MySQL;
+    username: sa
+  jpa:
+    hibernate:
+      ddl-auto: create
+
+jwt:
+  secret: secretkeysecretkeysecretkeysecretkeysecretkey


### PR DESCRIPTION
### `Planner` 및 `Daily`,  `Task`,  `Schedule` 도메인에 대한 서비스 계층 테스트 코드를 작성하였음.

사용자 테스트는 테스트 DB로 h2를 활용하여 **상태 검증을 진행**하였고,

그 외 테스트는 `mockito` 활용하여 **행위 검증을 진행**하였음.

> 서비스 계층 테스트 커버리지 100%

![image](https://github.com/AnTaeWook/amatda/assets/55526071/8d1dd058-d749-4b0f-a2c6-037a78fb9411)

This Closes #20 